### PR TITLE
sources/scaleway: url's can be overridden 

### DIFF
--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -259,7 +259,7 @@ class DataSourceScaleway(sources.DataSource):
 
         netcfg = {"type": "physical", "name": "%s" % self._fallback_interface}
         subnets = [{"type": "dhcp4"}]
-        if self.metadata["ipv6"]:
+        if 'ipv6' in self.metadata:
             subnets += [
                 {
                     "type": "static",

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -304,6 +304,7 @@ class DataSourceScaleway(sources.DataSource):
 
 datasources = [
     (DataSourceScaleway, (sources.DEP_FILESYSTEM,)),
+    (DataSourceScaleway, (sources.DEP_FILESYSTEM, sources.DEP_NETWORK)),
 ]
 
 

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -208,6 +208,10 @@ class DataSourceScaleway(sources.DataSource):
         self._network_config = sources.UNSET
 
     def _crawl_metadata(self):
+        # Stay backward compatible with classes w/o these attributes
+        self.headers = getattr(self, 'headers', None)
+        self.headers_redact = getattr(self, 'headers_redact', None)
+
         resp = url_helper.readurl(
             self.metadata_address, headers=self.headers, headers_redact=self.headers_redact, timeout=self.timeout, retries=self.retries
         )

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -195,6 +195,7 @@ class DataSourceScaleway(sources.DataSource):
         self.userdata_address = self.ds_cfg.get("custom_userdata_url", "{base_url}/user_data/cloud-init".format(base_url=self.ds_cfg.get("base_url", DS_BASE_URL)))
         self.vendordata_address = self.ds_cfg.get("custom_vendordata_url", "{base_url}/vendor_data/cloud-init".format(base_url=self.ds_cfg.get("base_url", DS_BASE_URL)))
         self.headers_redact = None
+        self.headers = None
         # Scaleway Baremetal product use X-Metadata-Auth-Token
         authToken = self.ds_cfg.get("token", None)
         if authToken is not None:

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -260,14 +260,15 @@ class DataSourceScaleway(sources.DataSource):
         netcfg = {"type": "physical", "name": "%s" % self._fallback_interface}
         subnets = [{"type": "dhcp4"}]
         if 'ipv6' in self.metadata:
-            subnets += [
-                {
-                    "type": "static",
-                    "address": "%s" % self.metadata["ipv6"]["address"],
-                    "gateway": "%s" % self.metadata["ipv6"]["gateway"],
-                    "netmask": "%s" % self.metadata["ipv6"]["netmask"],
-                }
-            ]
+            if self.metadata["ipv6"]:
+                subnets += [
+                    {
+                        "type": "static",
+                        "address": "%s" % self.metadata["ipv6"]["address"],
+                        "gateway": "%s" % self.metadata["ipv6"]["gateway"],
+                        "netmask": "%s" % self.metadata["ipv6"]["netmask"],
+                    }
+                ]
         netcfg["subnets"] = subnets
         self._network_config = {"version": 1, "config": [netcfg]}
         return self._network_config

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -69,6 +69,7 @@ DEFAULT_NETWORK = [
     OVF.DataSourceOVFNet,
     UpCloud.DataSourceUpCloud,
     VMware.DataSourceVMware,
+    Scaleway.DataSourceScaleway,
 ]
 
 


### PR DESCRIPTION
# Scaleway Baremetal cloud-init implementation

The Scaleway Bare Metal product needs to be able to override the default URL and to be able to pass an authentication token that Cloud-Init must use to authenticate on the Metadata API.

Base URL can be overridden with `base_url` field, but is it possible to override specific url with `custom_xxx_url` field.
**When `custom_xxx_url is defined`, the `base_url` is not used.**

Eg: Datasource config
```
datasource_list: [ "Scaleway" ]
datasource:
  Scaleway:
    base_url: https://metadata.par1.brm.scaleway.com
    custom_metadata_url: https://metadata.par1.brm.scaleway.com/meta-data
    custom_userdata_url: https://metadata.par1.brm.scaleway.com/user-data
    custom_vendordata_url: https://metadata.par1.brm.scaleway.com/vendor-data
    token: SECRET_TOKEN
```